### PR TITLE
Switch to new style Supervisor child spec

### DIFF
--- a/lib/bigflake/application.ex
+++ b/lib/bigflake/application.ex
@@ -4,12 +4,10 @@ defmodule Bigflake.Application do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     worker_id = Application.get_env(:bigflake, :worker_id)
 
     children = [
-      worker(Bigflake, [worker_id])
+      %{id: Bigflake, start: {Bigflake, :start_link, [worker_id]}}
     ]
 
     opts = [strategy: :one_for_one, name: Bigflake.Supervisor]


### PR DESCRIPTION
Ensures the following warning disappears:
```
warning: Supervisor.Spec.worker/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/bigflake/application.ex:12: Bigflake.Application.start/2
```