### PR TITLE
Update Elixir & Erlang/OTP build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,40 @@
 language: elixir
 elixir:
-  - 1.5
+  - 1.6
+  - 1.7
+  - 1.8
+  - 1.9
+  - 1.10
+  - 1.11
 otp_release:
   - 19.3
   - 20.0
+  - 21.0
+  - 22.0
+  - 23.0
+matrix:
+  exclude:
+  - elixir: 1.6
+    otp_release: 21.0
+  - elixir: 1.6
+    otp_release: 22.0
+  - elixir: 1.6
+    otp_release: 23.0
+  - elixir: 1.7
+    otp_release: 23.0
+  - elixir: 1.8
+    otp_release: 19.3
+  - elixir: 1.8
+    otp_release: 23.0
+  - elixir: 1.9
+    otp_release: 19.0
+  - elixir: 1.9
+    otp_release: 23.0
+  - elixir: 1.10
+    otp_release: 19.3
+  - elixir: 1.10
+    otp_release: 20.0
+  - elixir: 1.11
+    otp_release: 19.0
+  - elixir: 1.11
+    otp_release: 20.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,6 @@ matrix:
   - elixir: 1.10
     otp_release: 20.0
   - elixir: 1.11
-    otp_release: 19.0
+    otp_release: 19.3
   - elixir: 1.11
     otp_release: 20.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
   - elixir: 1.8
     otp_release: 23.0
   - elixir: 1.9
-    otp_release: 19.0
+    otp_release: 19.3
   - elixir: 1.9
     otp_release: 23.0
   - elixir: 1.10


### PR DESCRIPTION
💁 These changes update the build matrix of Elixir & Erlang/OTP versions based on [Elixir's current compatibility matrix](https://hexdocs.pm/elixir/1.11.3/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp).

Adds support for:
* Elixir versions 1.6 - 1.11, inclusive
* Erlang/OTP versions 21.0 - 23.0, inclusive

Removes:
* Elixir version 1.5